### PR TITLE
Bugfix - properly handle generics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,58 @@
 version = 3
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.43"
+name = "byteorder"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.160"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.160"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "storekey"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475592c1aa8849fa7874777c9df46aa93ffc47851c7c60bee88b1745a1adb893"
+dependencies = [
+ "byteorder",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -25,7 +62,8 @@ name = "surrealdb-derive"
 version = "0.7.0"
 dependencies = [
  "quote",
- "syn",
+ "storekey",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -37,6 +75,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ name = "surrealdb-derive"
 version = "0.7.0"
 dependencies = [
  "quote",
+ "serde",
  "storekey",
  "syn 1.0.99",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ syn = "1.0.96"
 quote = "1.0.18"
 
 [dev-dependencies]
+serde = { version = "1.0", features = ["derive"] }
 storekey = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 [dependencies]
 syn = "1.0.96"
 quote = "1.0.18"
+
+[dev-dependencies]
+storekey = "0.4"

--- a/examples/key.rs
+++ b/examples/key.rs
@@ -1,0 +1,37 @@
+// cargo expand --example key
+
+use surrealdb_derive::Key;
+
+mod err {
+	pub type Error = ();
+}
+
+mod sql {
+	pub mod serde {
+		pub fn beg_internal_serialization() {}
+		pub fn end_internal_serialization() {}
+	}
+}
+
+#[derive(Key)]
+pub struct NsOwned {
+	__: u8,
+	_a: u8,
+	_b: u8,
+	_c: u8,
+	pub ns: String,
+}
+
+/// WIP: Support for borrowed keys.
+#[derive(Key)]
+pub struct NsBorrowed<'a>
+// Extra where bound for testing macro.
+where
+	'a: 'static,
+{
+	__: u8,
+	_a: u8,
+	_b: u8,
+	_c: u8,
+	pub ns: &'a str,
+}

--- a/examples/key.rs
+++ b/examples/key.rs
@@ -1,9 +1,23 @@
 // cargo expand --example key
 
 use surrealdb_derive::Key;
+use serde::{Serialize, Deserialize};
 
 mod err {
-	pub type Error = ();
+	#[derive(Debug)]
+	pub struct Error;
+
+	impl From<storekey::encode::Error> for Error {
+		fn from(_: storekey::encode::Error) -> Self {
+			unimplemented!();
+		}
+	}
+
+	impl From<storekey::decode::Error> for Error {
+		fn from(_: storekey::decode::Error) -> Self {
+			unimplemented!();
+		}
+	}
 }
 
 mod sql {
@@ -13,7 +27,7 @@ mod sql {
 	}
 }
 
-#[derive(Key)]
+#[derive(Serialize, Deserialize, Key)]
 pub struct NsOwned {
 	__: u8,
 	_a: u8,
@@ -23,11 +37,8 @@ pub struct NsOwned {
 }
 
 /// WIP: Support for borrowed keys.
-#[derive(Key)]
+#[derive(Serialize, Deserialize, Key)]
 pub struct NsBorrowed<'a>
-// Extra where bound for testing macro.
-where
-	'a: 'static,
 {
 	__: u8,
 	_a: u8,
@@ -35,3 +46,5 @@ where
 	_c: u8,
 	pub ns: &'a str,
 }
+
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ pub fn key(input: TokenStream) -> TokenStream {
 			}
 		}
 
-		impl #impl_generics From<&Vec<u8>> for #name #ty_generics #where_clause {
+		impl #impl_generics From<&#lifetime Vec<u8>> for #name #ty_generics #where_clause {
 			fn from(v: &Vec<u8>) -> Self {
 				Self::decode(v).unwrap()
 			}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ pub fn key(input: TokenStream) -> TokenStream {
 	// Compute the generics
 	let generics = input.generics;
 	let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+	assert!(generics.lifetimes().count() <= 1);
 	let lifetime: quote::__private::TokenStream =
 		if let Some(lifetime_def) = generics.lifetimes().next() {
 			let lifetime = &lifetime_def.lifetime;


### PR DESCRIPTION
The generics implementation in #1 had a few extraneous where clauses.

I fixed it and added an example as a sanity check; see below for `cargo expand --example key`:

```rust
pub struct NsOwned {
    __: u8,
    _a: u8,
    _b: u8,
    _c: u8,
    pub ns: String,
}
impl From<NsOwned> for Vec<u8> {
    fn from(v: NsOwned) -> Vec<u8> {
        v.encode().unwrap_or_default()
    }
}
impl From<&NsOwned> for Vec<u8> {
    fn from(v: &NsOwned) -> Vec<u8> {
        v.encode().unwrap_or_default()
    }
}
impl From<Vec<u8>> for NsOwned {
    fn from(v: Vec<u8>) -> Self {
        Self::decode(&v).unwrap()
    }
}
impl From<&Vec<u8>> for NsOwned {
    fn from(v: &Vec<u8>) -> Self {
        Self::decode(v).unwrap()
    }
}
impl NsOwned {
    pub fn encode(&self) -> Result<Vec<u8>, crate::err::Error> {
        crate::sql::serde::beg_internal_serialization();
        let v = storekey::serialize(self);
        crate::sql::serde::end_internal_serialization();
        Ok(v?)
    }
    pub fn decode(v: &[u8]) -> Result<Self, crate::err::Error> {
        let v = storekey::deserialize(v);
        Ok(v?)
    }
}
/// WIP: Support for borrowed keys.
pub struct NsBorrowed<'a>
where
    'a: 'static,
{
    __: u8,
    _a: u8,
    _b: u8,
    _c: u8,
    pub ns: &'a str,
}
impl<'a> From<NsBorrowed<'a>> for Vec<u8>
where
    'a: 'static,
{
    fn from(v: NsBorrowed<'a>) -> Vec<u8> {
        v.encode().unwrap_or_default()
    }
}
impl<'a> From<&NsBorrowed<'a>> for Vec<u8>
where
    'a: 'static,
{
    fn from(v: &NsBorrowed<'a>) -> Vec<u8> {
        v.encode().unwrap_or_default()
    }
}
impl<'a> From<Vec<u8>> for NsBorrowed<'a>
where
    'a: 'static,
{
    fn from(v: Vec<u8>) -> Self {
        Self::decode(&v).unwrap()
    }
}
impl<'a> From<&Vec<u8>> for NsBorrowed<'a>
where
    'a: 'static,
{
    fn from(v: &Vec<u8>) -> Self {
        Self::decode(v).unwrap()
    }
}
impl<'a> NsBorrowed<'a>
where
    'a: 'static,
{
    pub fn encode(&self) -> Result<Vec<u8>, crate::err::Error> {
        crate::sql::serde::beg_internal_serialization();
        let v = storekey::serialize(self);
        crate::sql::serde::end_internal_serialization();
        Ok(v?)
    }
    pub fn decode(v: &'a [u8]) -> Result<Self, crate::err::Error> {
        let v = storekey::deserialize(v);
        Ok(v?)
    }
}
```